### PR TITLE
fix: typo

### DIFF
--- a/wechatrobot/Modles.py
+++ b/wechatrobot/Modles.py
@@ -251,7 +251,7 @@ class SendXmlBody(Body):
     img_path : str
 
 #logout
-class LogoutBody(Body):
+class LogOutBody(Body):
     ...
 
 #get transfer


### PR DESCRIPTION
logout 大小写不一致 https://github.com/0honus0/python-comwechatrobot-http/blob/a26ff8713012469e499f09ca2360e6c97864d46a/wechatrobot/Api.py#L146